### PR TITLE
Relax implementation of `.IsNotNil()` to return true for any value of a non-nillable type

### DIFF
--- a/pkg/utils/builder/builder_api.go
+++ b/pkg/utils/builder/builder_api.go
@@ -67,7 +67,7 @@ func (b *Builder) IsNil() *predicate.Predicate {
 }
 
 // IsNotNil tests if a value is neither a nil literal nor a nillable type set to
-// nil
+// nil; any value of a non-nillable type is considered not nil.
 func (b *Builder) IsNotNil() *predicate.Predicate {
 	b.p.RegisterPredicate(impl.IsNotNil())
 	if b.t != nil {

--- a/pkg/utils/predicate/impl/compare.go
+++ b/pkg/utils/predicate/impl/compare.go
@@ -52,7 +52,7 @@ func IsNil() (desc string, f predicate.PredicateFunc) {
 			return vv.IsNil(), nil, nil
 		default:
 			return false, nil, fmt.Errorf(
-				"value of type '%v' is never nil",
+				"value of type '%v' can never be nil",
 				vv.Type())
 		}
 	}
@@ -60,7 +60,7 @@ func IsNil() (desc string, f predicate.PredicateFunc) {
 }
 
 // IsNotNil tests if a value is neither a nil literal nor a nillable type set to
-// nil
+// nil; any value of a non-nillable type is considered not nil.
 func IsNotNil() (desc string, f predicate.PredicateFunc) {
 	desc = "{} is not nil"
 	f = func(v interface{}) (r bool, ctx []predicate.ContextValue, err error) {
@@ -74,9 +74,7 @@ func IsNotNil() (desc string, f predicate.PredicateFunc) {
 
 			return !vv.IsNil(), nil, nil
 		default:
-			return false, nil, fmt.Errorf(
-				"value of type '%v' can never be nil",
-				vv.Type())
+			return true, nil, nil
 		}
 	}
 	return

--- a/pkg/utils/predicate/impl/compare_test.go
+++ b/pkg/utils/predicate/impl/compare_test.go
@@ -34,7 +34,7 @@ func TestIsNil(t *testing.T) {
 	verifyPredicate(t, pr(impl.IsNil()), expectation{
 		value:    123,
 		pass:     false,
-		errorMsg: "value of type 'int' is never nil",
+		errorMsg: "value of type 'int' can never be nil",
 	})
 }
 
@@ -43,11 +43,10 @@ func TestIsNotNil(t *testing.T) {
 	verifyPredicate(t, pr(impl.IsNotNil()), expectation{value: &struct{}{}, pass: true})
 	verifyPredicate(t, pr(impl.IsNotNil()), expectation{value: nil, pass: false})
 	verifyPredicate(t, pr(impl.IsNotNil()), expectation{value: p, pass: false})
-	verifyPredicate(t, pr(impl.IsNotNil()), expectation{
-		value:    123,
-		pass:     false,
-		errorMsg: "value of type 'int' can never be nil",
-	})
+
+	verifyPredicate(t, pr(impl.IsNotNil()), expectation{value: 123, pass: true})
+	verifyPredicate(t, pr(impl.IsNotNil()), expectation{value: "123", pass: true})
+	verifyPredicate(t, pr(impl.IsNotNil()), expectation{value: struct{}{}, pass: true})
 }
 
 func TestIsEqualTo(t *testing.T) {


### PR DESCRIPTION
Fixes #20 