### PR TITLE
Add release notes for v1.6.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.24.x"
+          - "1.23.x"
           - "stable"
         os:
           - ubuntu-latest

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## Improvements
 
-- Update required Go version to 1.24
+- Update Go version requirement to 1.23 minimum (up from Go 1.19 in release v1.5.0, lowered from 1.24 in prior PR)
 - Cleanup `Panics()` predicate -- no more `panic(nil)` special case
 - Add `IsA()` predicate and `bdd.TypeOf()` for type assertion
 - Add `itertest.VerifySeqCanStopAfterN()` and `itertest.VerifySeq2CanStopAfterN()` to verify proper implementation of `iter.Seq` and `iter.Seq2` interfaces

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,22 @@
+# v1.6.0
+
+## Improvements
+
+- Update required Go version to 1.24
+- Cleanup `Panics()` predicate -- no more `panic(nil)` special case
+- Add `IsA()` predicate and `bdd.TypeOf()` for type assertion
+- Add `itertest.VerifySeqCanStopAfterN()` and `itertest.VerifySeq2CanStopAfterN()` to verify proper implementation of `iter.Seq` and `iter.Seq2` interfaces
+- Add `bdd.Used()`, `bdd.First()`, `bdd.Second()` and `bdd.Third()` convenience functions
+
+## Code changes
+
+- Update bifurcated execution model description ([#36](https://github.com/maargenton/go-testpredicate/pull/36))
+- Add `bdd.First()`, `bdd.Second()` and `bdd.Third()` helper functions ([#35](https://github.com/maargenton/go-testpredicate/pull/35))
+- Add ` IsA()` predicate for type assertion ([#34](https://github.com/maargenton/go-testpredicate/pull/34))
+- Add `itertest` package to test expected iterator behavior ([#33](https://github.com/maargenton/go-testpredicate/pull/33))
+- Update dependency to Go 1.24 ([#32](https://github.com/maargenton/go-testpredicate/pull/32))
+
+
 # v1.5.0
 
 ## Improvements

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/maargenton/go-testpredicate
 
-go 1.24
+go 1.23.0
 
 require golang.org/x/tools v0.34.0
 


### PR DESCRIPTION
- Update Go version requirement to 1.23 minimum (up from Go 1.19 in release v1.5.0, lowered from 1.24 in prior PR)